### PR TITLE
fix: don't load external frames until the button is clicked

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,13 +32,13 @@
           <guest-instructions />
         </v-container>
         <v-container :class="getClass('abrp')" fluid>
-          <a-b-r-p />
+          <frame :src="this.frameSrc['abrp']" />
         </v-container>
         <v-container :class="getClass('waze')" fluid>
-          <waze />
+          <frame :src="this.frameSrc['waze']" />
         </v-container>
         <v-container :class="getClass('plugshare')" fluid>
-          <plug-share />
+          <frame :src="this.frameSrc['plugshare']" />
         </v-container>
         <v-container :class="getClass('settings')" fluid>
           <settings />
@@ -60,26 +60,32 @@
 <script>
 import Welcome from "./components/Welcome.vue";
 import GuestInstructions from "./components/model3/GuestInstructions.vue";
-import ABRP from "./components/ABRP.vue";
-import Waze from "./components/Waze.vue";
-import PlugShare from "./components/PlugShare.vue";
 import Settings from "./components/Setup.vue";
+import Frame from "./components/Frame.vue";
 
 export default {
   components: {
     Welcome,
     GuestInstructions,
-    ABRP,
-    Waze,
-    PlugShare,
-    Settings
+    Settings,
+    Frame,
   },
   props: {
     source: String
   },
   data: function() {
     return {
-      active: "home"
+      active: "home",
+      frameSrc: {
+        "abrp": "",
+        "waze": "",
+        "plugshare": "",
+      },
+      defaultFrameSrc: {
+        "abrp": "https://new.abetterrouteplanner.com/",
+        "waze": "https://teslawaze.azurewebsites.net/",
+        "plugshare": "https://www.plugshare.com/",
+      },
     };
   },
   computed: {
@@ -99,6 +105,10 @@ export default {
   methods: {
     btnClick: function(id) {
       this.active = id;
+
+      if (this.defaultFrameSrc[id] && !this.frameSrc[id]) {
+        this.frameSrc[id] = this.defaultFrameSrc[id];
+      }
     },
     getClass: function(id) {
       return this.active === id ? "fill-height align-start" : "d-none";

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -1,8 +1,15 @@
 <template>
   <iframe
-    src="https://new.abetterrouteplanner.com/"
+    :src="this.src"
     width="100%"
     height="100%"
     style="border: 0;"
   />
 </template>
+<script>
+export default {
+  props: {
+    src: String,
+  },
+};
+</script>

--- a/src/components/PlugShare.vue
+++ b/src/components/PlugShare.vue
@@ -1,3 +1,0 @@
-<template>
-  <iframe src="https://www.plugshare.com//" width="100%" height="100%" style="border: 0;" />
-</template>

--- a/src/components/Waze.vue
+++ b/src/components/Waze.vue
@@ -1,8 +1,0 @@
-<template>
-  <iframe
-    src="https://teslawaze.azurewebsites.net/"
-    width="100%"
-    height="100%"
-    style="border: 0;"
-  />
-</template>


### PR DESCRIPTION
The Tesla browser doesn't remember location permissions, so this prevents the site from bombarding the user with location requests on initial load.